### PR TITLE
Parameterize Acme endpoint and send user data to the Acme API

### DIFF
--- a/.github/workflows/acme-hooli-integration.yml
+++ b/.github/workflows/acme-hooli-integration.yml
@@ -6,6 +6,7 @@ on:
       - main
 
 jobs:
+  # Build and publish Acme CRM component
   acme_component:
     runs-on: ubuntu-latest
     steps:
@@ -13,8 +14,6 @@ jobs:
       - uses: actions/setup-node@v4.0.2
       - name: Install dependencies
         run: yarn install
-
-      # Acme CRM Component
       - name: Build Acme CRM Component
         run: yarn build
         working-directory: components/acme-crm
@@ -25,6 +24,7 @@ jobs:
           PRISMATIC_URL: ${{ vars.PRISMATIC_URL }}
           PRISM_REFRESH_TOKEN: ${{ secrets.PRISM_REFRESH_TOKEN }}
 
+  # Build and publish Hooli CRM component
   hooli_component:
     runs-on: ubuntu-latest
     steps:
@@ -42,6 +42,7 @@ jobs:
           PRISMATIC_URL: ${{ vars.PRISMATIC_URL }}
           PRISM_REFRESH_TOKEN: ${{ secrets.PRISM_REFRESH_TOKEN }}
 
+  # Publish Acme-Hooli integration after components are published
   acme_hooli_integration:
     runs-on: ubuntu-latest
     needs: [acme_component, hooli_component]

--- a/.github/workflows/acme-hooli-integration.yml
+++ b/.github/workflows/acme-hooli-integration.yml
@@ -25,7 +25,7 @@ jobs:
           PRISMATIC_URL: ${{ vars.PRISMATIC_URL }}
           PRISM_REFRESH_TOKEN: ${{ secrets.PRISM_REFRESH_TOKEN }}
 
-  hooli_components:
+  hooli_component:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
 
   acme_hooli_integration:
     runs-on: ubuntu-latest
-    needs: [acme_component, hooli_components]
+    needs: [acme_component, hooli_component]
     steps:
       - uses: actions/checkout@v4
       - name: Publish Integration Component

--- a/components/acme-crm/src/index.ts
+++ b/components/acme-crm/src/index.ts
@@ -1,13 +1,20 @@
-import { action, component } from "@prismatic-io/spectral";
+import { action, component, input, util } from "@prismatic-io/spectral";
 
 const listUsers = action({
   display: {
     label: "List Users",
     description: "List all users in the system",
   },
-  inputs: {},
+  inputs: {
+    endpoint: input({
+      type: "string",
+      default: "https://jsonplaceholder.typicode.com/users",
+      label: "Users Endpoint",
+      clean: util.types.toString,
+    }),
+  },
   perform: async (context, params) => {
-    const response = await fetch("https://jsonplaceholder.typicode.com/users");
+    const response = await fetch(params.endpoint);
     const users = await response.json();
     return { data: users };
   },

--- a/integrations/hooli-acme-integration.yml
+++ b/integrations/hooli-acme-integration.yml
@@ -78,6 +78,94 @@ flows:
             key: acme-crm
             version: LATEST
         description: ""
-        inputs: {}
+        inputs:
+          endpoint:
+            type: value
+            value: "https://jsonplaceholder.typicode.com/users"
         name: List Users
+      - action:
+          key: runCode
+          component:
+            isPublic: true
+            key: code
+            version: LATEST
+        description: ""
+        inputs:
+          code:
+            type: value
+            value: |
+              /*
+                Access config variables by name through the configVars object. e.g.
+                  const apiEndpoint = `${configVars["App Base URL"]}/api`;
+
+                Access previous steps' results through the stepResults object. Trigger
+                and step names are camelCased. If the step "Get Data from API" returned
+                {"foo": "bar", "baz": 123}, you could destructure that data with:
+                  const { foo, baz } = stepResults.getDataFromApi.results;
+
+                You can return string, number or complex object data. e.g.
+                  return { data: { foo: "Hello", bar: 123.45, baz: true } };
+              */
+
+              module.exports = async ({ logger, configVars }, stepResults) => {
+                const users = stepResults.listUsers.results;
+                const payload = users.map((user) => ({
+                  name: user.name,
+                  phone: user.phone,
+                  email: user.email,
+                }));
+                return { data: payload };
+              };
+        name: Code Block
+      - action:
+          key: httpPost
+          component:
+            isPublic: true
+            key: http
+            version: LATEST
+        description: ""
+        inputs:
+          connection:
+            type: configVar
+            value: ""
+          data:
+            type: reference
+            value: codeBlock.results
+          debugRequest:
+            type: value
+            value: "false"
+          headers:
+            type: complex
+            value: []
+          ignoreSslErrors:
+            type: value
+            value: "false"
+          includeFullResponse:
+            type: value
+            value: "false"
+          maxRetries:
+            type: value
+            value: "0"
+          queryParams:
+            type: complex
+            value: []
+          responseType:
+            type: value
+            value: json
+          retryDelayMS:
+            type: value
+            value: "0"
+          retryOnAllErrors:
+            type: value
+            value: "false"
+          timeout:
+            type: value
+            value: ""
+          url:
+            type: value
+            value: "https://api.acme.com/users"
+          useExponentialBackoff:
+            type: value
+            value: "false"
+        name: POST Request
 name: Hooli - Acme Integration


### PR DESCRIPTION
The removes the hard-coded Acme endpoint and allows an integration builder to specify their own Acme endpoint.

Additionally, user data pulled from Acme is now parsed and posted to Hooli.